### PR TITLE
fix(markdown3) KeyError: configs

### DIFF
--- a/mdx_cite.py
+++ b/mdx_cite.py
@@ -28,12 +28,13 @@ Copyright
 2011, 2012 [The active archives contributors](http://activearchives.org/)
 All rights reserved.
 
-This software is released under the modified BSD License. 
+This software is released under the modified BSD License.
 See LICENSE.md for details.
 '''
 
 
 import markdown
+
 from markdown.inlinepatterns import SimpleTagPattern
 
 
@@ -45,11 +46,13 @@ class CiteExtension(markdown.extensions.Extension):
 
     def extendMarkdown(self, md, md_globals):
         """Modifies inline patterns"""
-        md.inlinePatterns.add('cite', SimpleTagPattern(CITE_RE, 'cite'), '<not_strong')
+        md.inlinePatterns.add(
+            'cite', SimpleTagPattern(
+                CITE_RE, 'cite'), '<not_strong')
 
 
-def makeExtension(configs={}):
-    return CiteExtension(configs=dict(configs))
+def makeExtension():
+    return CiteExtension()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### 1. Summary

I fix critical error for Markdown 3 and higher.

### 2. Testing environment

+ Windows 10 Enterprise LTSB 64-bit EN,
+ Python 3.7.1,
+ Pelican 4.0.1,
+ Python Markdown 3.0.1.

### 3. Steps to reproduce

I create simple Pelican site → I download and add `mdx_cite` plugin → `pelican content`.

### 4. Behavior before pull request

```text
ERROR: Could not process Sublime-Text\SashaSublime.md
  | KeyError: 'configs'
ERROR: Could not process Gingerinas\Грейзи-Фа.md
  | KeyError: 'configs'
ERROR: Could not process Sasha-Black\Sasha-Black-description.md
  | KeyError: 'configs'
ERROR: Could not process Gingerinas\АльFAQ.md
  | KeyError: 'configs'
ERROR: Could not process IT-articles\typo-reporter.md
  | KeyError: 'configs'
CRITICAL: RuntimeError: generator raised StopIteration
```

### 5. Behavior after pull request

No errors.

Thanks.